### PR TITLE
Remove spurious space

### DIFF
--- a/lua-ul.dtx
+++ b/lua-ul.dtx
@@ -818,7 +818,7 @@ luatexbase.add_to_callback('vpack_filter',
   \def\luaul@@setcolor\xcolor@#1#2{}
   \newcommand\luaul@setcolor[1]{%
     \ifx\XC@getcolor\undefined
-      \def\luaul@highlight@currentcolor{#1}
+      \def\luaul@highlight@currentcolor{#1}%
     \else
       \begingroup
         \XC@getcolor{#1}\luaul@tmpcolor


### PR DESCRIPTION
This should get rid of the excess space before "ipsum" in
```latex
\documentclass{article}
\usepackage{luacolor}
\usepackage{lua-ul}


\begin{document}
Lorem \highLight{ipsum} dolor

Lorem ipsum dolor

\highLight{Lorem}
\end{document}
```
![Lorem  ipsum dolor/Lorem ipsum dolor](https://user-images.githubusercontent.com/6755835/83967464-e4dc0380-a8c1-11ea-9216-cf7294d72377.png)
